### PR TITLE
feat(api): POST/GET endpoints for comment history

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,6 @@
+import "dotenv/config";
 import express from "express";
+import { commentsRouter } from "./routes/comments";
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -8,6 +10,8 @@ app.use(express.json());
 app.get("/health", (_req, res) => {
   res.json({ status: "ok" });
 });
+
+app.use("/api/comments", commentsRouter);
 
 app.listen(PORT, () => {
   console.log(`API running on http://localhost:${PORT}`);

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -1,0 +1,54 @@
+import { Router, type IRouter } from "express";
+import { desc, eq } from "drizzle-orm";
+import { db } from "../db";
+import { commentHistory } from "../db/schema";
+
+export const commentsRouter: IRouter = Router();
+
+commentsRouter.post("/", async (req, res) => {
+  const { username, comment_text, style } = req.body;
+
+  if (!username || !comment_text || !style) {
+    res.status(400).json({ error: "username, comment_text, and style are required" });
+    return;
+  }
+
+  const [row] = await db
+    .insert(commentHistory)
+    .values({
+      instagramUsername: username,
+      commentText: comment_text,
+      style,
+    })
+    .returning();
+
+  res.status(201).json(row);
+});
+
+commentsRouter.get("/:username/last", async (req, res) => {
+  const { username } = req.params;
+
+  const [row] = await db
+    .select()
+    .from(commentHistory)
+    .where(eq(commentHistory.instagramUsername, username))
+    .orderBy(desc(commentHistory.commentedAt))
+    .limit(1);
+
+  if (!row) {
+    res.status(404).json({ error: "No comment found for this username" });
+    return;
+  }
+
+  const now = new Date();
+  const daysAgo = Math.max(
+    0,
+    Math.floor((now.getTime() - row.commentedAt.getTime()) / (1000 * 60 * 60 * 24))
+  );
+
+  res.json({
+    username: row.instagramUsername,
+    last_commented_at: row.commentedAt.toISOString(),
+    days_ago: daysAgo,
+  });
+});


### PR DESCRIPTION
## Summary

- `POST /api/comments` — enregistre un commentaire (username, comment_text, style) → 201
- `GET /api/comments/:username/last` — retourne le dernier commentaire + `days_ago` → 200 ou 404
- Validation des inputs requis → 400

## Files

- `apps/api/src/routes/comments.ts` (nouveau) — Router Express avec les 2 endpoints
- `apps/api/src/index.ts` (modifié) — monte le router sur `/api/comments`

## Test plan

- [x] `pnpm build` passe (3/3)
- [x] POST enregistre en DB et retourne 201
- [x] GET retourne `{ username, last_commented_at, days_ago }` 
- [x] GET retourne 404 pour un username inconnu
- [x] POST retourne 400 si champs manquants

Closes #2