### PR TITLE
feat(extension): anti-spam warning + comment recording

### DIFF
--- a/apps/extension/src/components/SpamWarning.tsx
+++ b/apps/extension/src/components/SpamWarning.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  username: string;
+  daysAgo: number;
+}
+
+export function SpamWarning({ username, daysAgo }: Props) {
+  return (
+    <div className="spam-warning">
+      ⚠️ Tu as commenté sur @{username} il y a {daysAgo} jour{daysAgo !== 1 ? "s" : ""}. Commenter trop souvent peut sembler spam.
+    </div>
+  );
+}

--- a/apps/extension/src/hooks/useClaude.ts
+++ b/apps/extension/src/hooks/useClaude.ts
@@ -8,10 +8,10 @@ export function useClaude(apiKey: string | null) {
   const [error, setError] = useState<string | null>(null);
 
   const send = useCallback(
-    async (prompt: string) => {
+    async (prompt: string): Promise<ParsedResult | null> => {
       if (!apiKey) {
         setError("Clé API manquante.");
-        return;
+        return null;
       }
 
       setLoading(true);
@@ -22,10 +22,12 @@ export function useClaude(apiKey: string | null) {
         const raw = await callClaude(apiKey, prompt);
         const parsed = parseResponse(raw);
         setResult(parsed);
+        return parsed;
       } catch (err) {
         const msg =
           err instanceof Error ? err.message : "Une erreur est survenue.";
         setError(msg);
+        return null;
       } finally {
         setLoading(false);
       }

--- a/apps/extension/src/hooks/usePostContent.ts
+++ b/apps/extension/src/hooks/usePostContent.ts
@@ -1,7 +1,13 @@
 import { useState, useCallback } from "react";
 
+function parseAuthorUsername(content: string): string | null {
+  const match = content.match(/\[Auteur: @(.+?)\]/);
+  return match ? match[1] : null;
+}
+
 export function usePostContent() {
   const [postContent, setPostContent] = useState<string | null>(null);
+  const [authorUsername, setAuthorUsername] = useState<string | null>(null);
   const [extracting, setExtracting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -48,6 +54,7 @@ export function usePostContent() {
       }
 
       setPostContent(content);
+      setAuthorUsername(parseAuthorUsername(content));
       return content;
     } catch (err) {
       const msg =
@@ -59,5 +66,5 @@ export function usePostContent() {
     }
   }, []);
 
-  return { postContent, extracting, error, extract, setPostContent };
+  return { postContent, authorUsername, extracting, error, extract, setPostContent };
 }

--- a/apps/extension/src/lib/api.ts
+++ b/apps/extension/src/lib/api.ts
@@ -1,0 +1,30 @@
+const API_BASE = "http://localhost:3001";
+export const SPAM_THRESHOLD_DAYS = 3;
+
+export interface LastCommentInfo {
+  username: string;
+  last_commented_at: string;
+  days_ago: number;
+}
+
+export async function checkLastComment(username: string): Promise<LastCommentInfo | null> {
+  try {
+    const res = await fetch(`${API_BASE}/api/comments/${encodeURIComponent(username)}/last`);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function recordComment(username: string, commentText: string, style: string): Promise<void> {
+  try {
+    await fetch(`${API_BASE}/api/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, comment_text: commentText, style }),
+    });
+  } catch {
+    // fail silently
+  }
+}

--- a/apps/extension/src/styles/index.css
+++ b/apps/extension/src/styles/index.css
@@ -261,6 +261,18 @@ h1 {
   color: #4caf50;
 }
 
+/* Spam warning */
+.spam-warning {
+  margin: 12px 0;
+  padding: 10px 12px;
+  background: #fff8e1;
+  border: 1px solid #ffc107;
+  border-radius: 8px;
+  font-size: 13px;
+  color: #8d6e00;
+  line-height: 1.4;
+}
+
 /* Error */
 .error-container {
   margin-top: 16px;


### PR DESCRIPTION
## Summary

- After extracting a post, check `GET /api/comments/:username/last` for recent activity
- If commented less than 3 days ago, show a yellow warning banner (non-blocking)
- After generating a comment, record it via `POST /api/comments`
- All API calls fail silently — extension works fine even if API is down

## Files

- `apps/extension/src/lib/api.ts` (new) — `checkLastComment`, `recordComment`, `SPAM_THRESHOLD_DAYS`
- `apps/extension/src/components/SpamWarning.tsx` (new) — warning banner component
- `apps/extension/src/components/MainScreen.tsx` (modified) — integrate spam check + recording
- `apps/extension/src/hooks/usePostContent.ts` (modified) — expose `authorUsername`
- `apps/extension/src/hooks/useClaude.ts` (modified) — `send()` now returns `ParsedResult`
- `apps/extension/src/styles/index.css` (modified) — `.spam-warning` styles

## Test plan

- [x] `pnpm build` passes (3/3)
- [x] Warning shows if `days_ago < 3`
- [x] Comment recorded via POST after generation
- [x] Extension works if API is unreachable (fail silently)

Closes #3